### PR TITLE
Fixed a bug that caused the length of the drupal7 salt to be reported incorrectly and fail

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -751,7 +751,7 @@ static char *d7_hash(int use_md5, char *string1, int len1, char *string2, int le
 
 // The first 12 characters of an existing hash are its setting string.
 static char * d7_password_crypt(int use_md5, char *password, char *setting) {
-	char salt[8], *old, *new, *final;
+	char salt[9], *old, *new, *final;
 	int expected, count, count_log2 = d7_password_get_count_log2(setting);
 	int len;
 
@@ -762,6 +762,7 @@ static char * d7_password_crypt(int use_md5, char *password, char *setting) {
 	}
 
 	strncpy(salt, &setting[4], 8);
+	salt[8] = '\0';
 	if (strlen(salt) != 8) {
 		syslog(LOG_AUTHPRIV | LOG_ERR, PAM_MYSQL_LOG_PREFIX "_password_crypt: Salt length is not 8.");
 		return NULL;


### PR DESCRIPTION
strncpy does not null-terminate the destination if it truncates the source string. strlen requires a null character to properly report the length. See the following for explanation and examples: http://stackoverflow.com/questions/1176737/strncpy-and-using-sizeof-to-copy-maximum-characters

I Increased the size of salt and added a null char at the end so that strlen() returns the proper length of the salt.

I am not sure how/why this ever worked on your system? Only possible explanation I have would be a different compiler or architecture (I'm using RHEL6 x86_64) or you got lucky during testing and had a null char in memory following the char salt[8].

Thanks!
