### PR TITLE
Adds Dmitry Mikhailov's patch to plug memory leak.

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -2572,6 +2572,8 @@ static void pam_mysql_close_db(pam_mysql_ctx_t *ctx)
 
 	mysql_close(ctx->mysql_hdl);
 
+	mysql_library_end();
+
 	xfree(ctx->mysql_hdl);
 	ctx->mysql_hdl = NULL;
 }


### PR DESCRIPTION
See http://sourceforge.net/p/pam-mysql/bugs/27/#c2aa for details.
In case it goes missing:

Anon/reporter: mysql has a known memory leak between the
call of mysql_init, mysql_real_connect and mysql_close.

Dmitry: My solution is the following patch against 'latest'
pam_mysql-0.7RC1. But mysql_library_end() requires MySQL
at least version 4.1.10. For previous versions use
mysql_server_end() instead.
