### PR TITLE
Fix missing return value in pam_mysql_drupal7_data() function.

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -837,6 +837,8 @@ static char *pam_mysql_drupal7_data(const unsigned char *pwd, unsigned int sz, c
   }
   memcpy(md, hashed, strlen(hashed));
   xfree(hashed);
+
+  return md;
 }
 #endif
 /* }}} */


### PR DESCRIPTION
pam_mysql_drupal7_data() function does not return anything on success.
Return value is not used anywhere but might be confusing when used accidentally.

openSUSE Build Service will not allow to build the package while there are warnings
about no return values for non void functions.