### PR TITLE
replace deprecated AM_CONFIG_HEADER with AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT(pam-mysql, 0.8)
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([-Wall -Wno-extra-portability dist-xz no-dist-gzip])
 AC_CONFIG_SRCDIR(pam_mysql.c)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 AC_SUBST(PACKAGE_VERSION)
 AC_SUBST(PACKAGE_NAME)


### PR DESCRIPTION
This is a change that is currently applied in the Gentoo package of pam_mysql, it replaces an outdated autotools macro.

It seems that this has been deprecated and temporarily undeprecated again [1], so it currently won't cause failures, but it shouldn't hurt to replace it.

[1] https://autotools.io/forwardporting/automake.html