### PR TITLE
Use correct scrambled password function (issue #29)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,6 @@ AC_SEARCH_LIBS([crypt],[crypt],,[AC_MSG_ERROR([unable to find the crypt() functi
 
 AC_SUBST(PAM_MODS_DIR)
 AC_CONFIG_FILES([Makefile pam_mysql.spec])
-AC_SEARCH_LIBS([my_make_scrambled_password],[mysql],[AC_DEFINE([HAVE_MY_MAKE_SCRAMBLED_PASSWORD], [1], [Build own SHA1 support.])])
+AC_SEARCH_LIBS([make_scrambled_password],[mysql],[AC_DEFINE([HAVE_MAKE_SCRAMBLED_PASSWORD], [1], [Build own SHA1 support.])])
 
 AC_OUTPUT

--- a/crypto-md5.c
+++ b/crypto-md5.c
@@ -25,7 +25,7 @@ documentation and/or software.
 
 #include <config.h>
 
-#ifndef HAVE_MY_MAKE_SCRAMBLED_PASSWORD
+#ifndef HAVE_MAKE_SCRAMBLED_PASSWORD
 
 #include <string.h>
 #include "crypto.h"

--- a/crypto-sha1.c
+++ b/crypto-sha1.c
@@ -14,7 +14,7 @@
 
 #include <config.h>
 
-#ifndef HAVE_MY_MAKE_SCRAMBLED_PASSWORD
+#ifndef HAVE_MAKE_SCRAMBLED_PASSWORD
 
 #include <string.h>
 #include "crypto.h"

--- a/crypto.c
+++ b/crypto.c
@@ -37,7 +37,7 @@ char *hexify(char * const result, const unsigned char *digest,
 char *hexify(char * const result, const unsigned char *digest,
 	     const size_t size_result, size_t size_digest)
 {
-    static const char * const hexchars = "0123456789abcdef";
+    static const char * const hexchars = "0123456789ABCDEF";
     char *result_pnt = result;
 
     if (size_digest <= (size_t) 0 ||

--- a/crypto.c
+++ b/crypto.c
@@ -1,6 +1,6 @@
 #include <config.h>
 
-#ifndef HAVE_MY_MAKE_SCRAMBLED_PASSWORD
+#ifndef HAVE_MAKE_SCRAMBLED_PASSWORD
 
 #include <stdint.h>
 #include <string.h>

--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -168,14 +168,14 @@
 #define PAM_AUTHTOK_RECOVERY_ERR PAM_AUTHTOK_RECOVER_ERR
 #endif
 
-#ifdef HAVE_MY_MAKE_SCRAMBLED_PASSWORD
-void my_make_scrambled_password(char scrambled_password[42], const char password[255], int len);
+#ifdef HAVE_MAKE_SCRAMBLED_PASSWORD
+void make_scrambled_password(char scrambled_password[42], const char password[255], int len);
 #else
 #include "crypto.h"
 #include "crypto-sha1.h"
 
 // Implementation from commit 2db6b50c7b7c638104bd9639994f0574e8f4813c in Pure-ftp source.
-static void my_make_scrambled_password(char scrambled_password[42], const char password[255], int len)
+static void make_scrambled_password(char scrambled_password[42], const char password[255], int len)
 {
 	SHA1_CTX      ctx;
 	unsigned char h0[20], h1[20];
@@ -2927,10 +2927,10 @@ static pam_mysql_err_t pam_mysql_check_passwd(pam_mysql_ctx_t *ctx,
               if (ctx->use_323_passwd) {
                 make_scrambled_password_323(buf, passwd);
               } else {
-                my_make_scrambled_password(buf, passwd, strlen(passwd));
+                make_scrambled_password(buf, passwd, strlen(passwd));
               }
 #else
-              my_make_scrambled_password(buf, passwd, strlen(passwd));
+              make_scrambled_password(buf, passwd, strlen(passwd));
 #endif
 
               vresult = strcmp(row[0], buf);
@@ -3172,10 +3172,10 @@ static pam_mysql_err_t pam_mysql_update_passwd(pam_mysql_ctx_t *ctx, const char 
         if (ctx->use_323_passwd) {
           make_scrambled_password_323(encrypted_passwd, new_passwd);
         } else {
-          my_make_scrambled_password(encrypted_passwd, new_passwd, strlen(new_passwd));
+          make_scrambled_password(encrypted_passwd, new_passwd, strlen(new_passwd));
         }
 #else
-        my_make_scrambled_password(encrypted_passwd, new_passwd, strlen(new_passwd));
+        make_scrambled_password(encrypted_passwd, new_passwd, strlen(new_passwd));
 #endif
         break;
 


### PR DESCRIPTION
Here is a suggested fix. It will try to use mysql's make_scrambled_password() if it exists, and your own implementation if it doesn't.
To match the headers from mysql, I had to change the implementation to drop the last length argument.
Finally, I also changed hexify to return capital letters, as that is how the hex string is stored on the mysql server when using the PASSWORD() function.