### PR TITLE
Patch for build on CentOS 6

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,5 +8,6 @@ pam_mysql_la_CPPFLAGS = $(openssl_CFLAGS)
 pam_mysql_la_LIBADD   = $(openssl_LIBS) -lpam
 
 EXTRA_DIST = INSTALL.pam-mysql
+ACLOCAL_AMFLAGS = -I m4
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --with-pam-mods-dir=\$${prefix}/lib/security

--- a/configure.ac
+++ b/configure.ac
@@ -1,3 +1,4 @@
+m4_pattern_allow([AC_DEFINE])
 AC_PREREQ([2.58])
 AC_INIT(pam-mysql, 0.8)
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Not sure if this breaks the compatibility on other distributions, but on CentOS 6 building (autoreconf and configure) only works with these modifications.
Please check on other dists.