### PR TITLE
Catch result sets with >2 entries

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -2884,7 +2884,7 @@ static pam_mysql_err_t pam_mysql_check_passwd(pam_mysql_ctx_t *ctx,
       case 1:
         break;
 
-      case 2:
+      default:
         syslog(LOG_AUTHPRIV | LOG_ERR, "%s", PAM_MYSQL_LOG_PREFIX "SELECT returned an indetermined result.");
         err = PAM_MYSQL_ERR_UNKNOWN;
         goto out;


### PR DESCRIPTION
Any SELECTs returning more that 2 results were passed through as legit.
This commit fixes that by modifying the switch statement to catch
anything besides 0 or 1 results, instead of limiting to 0, 1, or 2
results.