### PR TITLE
Removed erroneous config file option from README

### DIFF
--- a/README
+++ b/README
@@ -223,7 +223,6 @@ config_file
     - users.database (db)
     - users.db_user (user)
     - users.db_passwd (passwd)
-    - users.where_clause (host)
     - users.table (table)
     - users.update_table (update_table)
     - users.user_column (usercolumn)


### PR DESCRIPTION
This removes one line from the list of possible config_file options since `users.where_clause` occurred twice: `users.where_clause (host)` vs. `users.where_clause (where)`