### PR TITLE
Avoid segmentation fault on unexpected Joomla hash value

### DIFF
--- a/pam_mysql.c
+++ b/pam_mysql.c
@@ -3834,6 +3834,11 @@ static pam_mysql_err_t pam_mysql_check_passwd(pam_mysql_ctx_t *ctx,
                                 char *salt = row[0];
                                 char *hash = strsep(&salt,":");
 
+                                if (!salt) {
+                                    syslog(LOG_AUTHPRIV | LOG_WARNING, PAM_MYSQL_LOG_PREFIX "unknown hash format");
+                                    err = PAM_MYSQL_ERR_MISMATCH;
+                                    goto out;
+                                }
                                 int len = strlen(passwd)+strlen(salt);
 
                                 char *tmp;


### PR DESCRIPTION
For example Joomla 3.2 uses crypt-like formats (like $P$...), which
aren't colon-separated, so salt becomes NULL and strlen() bombs.