### PR TITLE
Endianness

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ dnl For PureFTP crypto.
 AC_CHECK_SIZEOF(short)
 AC_CHECK_SIZEOF(int)
 AC_CHECK_SIZEOF(long)
+AC_C_BIGENDIAN
 
 AC_CHECK_HEADERS([arpa/inet.h netinet/in.h netdb.h string.h strings.h sys/socket.h sys/types.h sys/stat.h sys/param.h fcntl.h syslog.h unistd.h stdarg.h errno.h crypt.h security/pam_appl.h])
 AC_TYPE_SIZE_T

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,6 @@ PAM_MYSQL_CHECK_BLOWFISH
 
 AC_SUBST(PAM_MODS_DIR)
 AC_CONFIG_FILES([Makefile pam_mysql.spec])
-AC_SEARCH_LIBS([make_scrambled_password],[mysql],[AC_DEFINE([HAVE_MAKE_SCRAMBLED_PASSWORD], [1], [Build own SHA1 support.])])
+AC_SEARCH_LIBS([make_scrambled_password],[mysql],[AC_DEFINE([HAVE_MAKE_SCRAMBLED_PASSWORD], [1], [Define to 1 if make_scrambled_password is available])])
 
 AC_OUTPUT


### PR DESCRIPTION
The bundled SHA-1 implementation gave wrong results on big endian architectures because of the missing Autoconf check.
The comment fix is unrelated and does not change behavior.