### PR TITLE
Drop install script in favour of naming pam_mysql.so correctly in meson build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-strip /lib/security/libpam_mysql.so
-if [ -f /etc/redhat-release ]; then
-  mv -f /lib/security/libpam_mysql.so /usr/lib64/security/pam_mysql.so
-  rmdir /lib/security
-else
-  mv -f /lib/security/libpam_mysql.so /lib/security/pam_mysql.so
-fi

--- a/meson.build
+++ b/meson.build
@@ -267,9 +267,7 @@ buildtarget = shared_library('pam_mysql', [
   'src/password.c',
   'src/md5.c',
   'src/pam_calls.c',
-], dependencies: deps, install: true, include_directories: configuration_inc, install_dir: '/lib/security')
-
-meson.add_install_script('install.sh')
+], dependencies: deps, install: true, include_directories: configuration_inc, name_prefix: '', install_dir: '/lib/security')
 
 test_acct_mgmt = executable('test_acct_mgmt',
   sources: [


### PR DESCRIPTION
This sets the `name_prefix` for the `shared_library` 'pam_mysql' target to an empty string. The resulting `.so` file will be named `pam_mysql.so` (instead of `libpam_mysql.so`) so it doesn't need to be renamed by an install script.