### PR TITLE
Set install_dir to libdir/security rather than hardcoding it

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -267,7 +267,7 @@ buildtarget = shared_library('pam_mysql', [
   'src/password.c',
   'src/md5.c',
   'src/pam_calls.c',
-], dependencies: deps, install: true, include_directories: configuration_inc, install_dir: '/lib/security')
+], dependencies: deps, install: true, include_directories: configuration_inc, install_dir: join_paths(get_option('libdir'), 'security'))
 
 meson.add_install_script('install.sh')
 


### PR DESCRIPTION
This should fix #80
Please take it with a grain of salt though since I do not know if this is the way to do this properly in meson